### PR TITLE
add: cleanup.ts and update package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     },
     "scripts": {
         "compile:type": "tsc --project tsconfig-node.json --declaration --declarationDir dist --emitDeclarationOnly && tsc-alias -p tsconfig-types.json",
-        "compile:browser": "tsc --project tsconfig-browser.json && tsc-alias -p tsconfig-browser.json && rm -Rf dist/node/mocks && rm -Rf dist/node/spec && rm -Rf dist/node/debug",
-        "compile:node": "tsc --project tsconfig-node.json && tsc-alias -p tsconfig.json && rm -Rf dist/browser/mocks && rm -Rf dist/browser/spec && rm -Rf dist/browser/debug",
+        "compile:browser": "tsc --project tsconfig-browser.json && tsc-alias -p tsconfig-browser.json && ts-node src/commands/cleanup.ts",
+        "compile:node": "tsc --project tsconfig-node.json && tsc-alias -p tsconfig.json && ts-node src/commands/cleanup.ts",
         "build": "npm run compile:type && npm run compile:browser && npm run compile:node && npm pack",
         "lint": "eslint src/**/*.ts",
         "repl": "ts-node --project tsconfig.json -r tsconfig-paths/register",

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -1,0 +1,26 @@
+// use node FS to delete side-effect folder & files
+
+import fsPromises from 'node:fs/promises';
+
+const DELETE_PATHS = [
+    'dist/node/mocks',
+    'dist/node/spec',
+    'dist/node/debug',
+    'dist/browser/mocks',
+    'dist/browser/spec',
+    'dist/browser/debug',
+];
+
+const main = async () => {
+    try {
+        const tasks = DELETE_PATHS.map(path => {
+            fsPromises.rm(path, { force: true, recursive: true, });
+        });
+        await Promise.all(tasks);
+        // console.log(`success, ${DELETE_PATHS.length} subfolders are deleted`);
+    } catch {
+        console.error('Failed to clean up, check /src/commands/clean.ts');
+    }
+};
+
+main();


### PR DESCRIPTION
Issue:
- where -rm command not working on windows, related to [Issue](https://github.com/pockettojs/pocketto/issues/10)

Solution : 
- create cleanup.ts using node:fs modules

Test: able to build in my
- ✓ windows vscode 
- ✓ ubuntu vscode

![image](https://github.com/user-attachments/assets/8d7c55cf-dfcb-4383-9a60-c0563b9ea4db)
![image](https://github.com/user-attachments/assets/1b47c13a-0c59-4b43-a51a-c11941a24f46)

